### PR TITLE
Stop-on-failure request executors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.vizanarkonin</groupId>
     <artifactId>keres</artifactId>
-    <version>1.3.2</version>
+    <version>1.4.0</version>
 
     <name>Keres</name>
     <description>A code-powered load generation and performance testing tool</description>
@@ -29,7 +29,7 @@
     <scm>
         <connection>scm:git:git://github.com/The-Erebus-Project/Keres.git</connection>
         <developerConnection>scm:git:ssh://github.com:The-Erebus-Project/Keres.git</developerConnection>
-        <url>https://github.com/The-Erebus-Project/Keres/tree/master</url>
+        <url>https://github.com/The-Erebus-Project/Keres/tree/main</url>
     </scm>
 
     <properties>


### PR DESCRIPTION
+ Added stop-on-fail request executors to HTTP client - it will execute given request(s), and if one turns up failed - it will trigger virtual user shut-down. Useful for context-sensetive scenarios when continuing without certain state (auth, for example) serves no purpose.
~ Slightly reworked KeresUser storage - they now use thread ID as a key, and there's only 1 centralized storage now (in KeresUser class) - there was a redundant copy of it in ScenarioController. It is now removed.
+ Added mockAndStopIfFailed request processor to KeresClientBase - works the same way as new executor for HTTP client, but it "mocks" the request. Used for debugging/demonstration purposes