### PR TITLE
Cllient flow control additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ First step is adding the core dependency in your project **.pom** file:
 <dependency>
     <groupId>io.github.vizanarkonin</groupId>
     <artifactId>keres</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.vizanarkonin</groupId>
     <artifactId>keres</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
 
     <name>Keres</name>
     <description>A code-powered load generation and performance testing tool</description>


### PR DESCRIPTION
+ Added attempt controller to ClientBase - it allows user to run certain action for given amount of times until it succeeds. If no attempts were successful - it will trigger virtual user shut down.
+ Added attempt controller to Http client - it does the same as base one, except it takes an Http request builder. It executes it and yields only if response was not a failure and not a system failure. ~ Generalized client shutdown request - it can now be called from the client itself. It handles thread resolving and exception throwing on it's own.